### PR TITLE
Allow Update of Leading/TrailingButtons in MapTemplateConfig

### DIFF
--- a/ios/RNCarPlay.m
+++ b/ios/RNCarPlay.m
@@ -577,6 +577,16 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
         [mapTemplate setTripEstimateStyle:[RCTConvert CPTripEstimateStyle:config[@"tripEstimateStyle"]]];
     }
 
+    if ([config objectForKey:@"leadingNavigationBarButtons"]){
+        NSArray *leadingNavigationBarButtons = [self parseBarButtons:[RCTConvert NSArray:config[@"leadingNavigationBarButtons"]] templateId:templateId];
+        [mapTemplate setLeadingNavigationBarButtons:leadingNavigationBarButtons];
+    }
+  
+    if ([config objectForKey:@"trailingNavigationBarButtons"]){
+        NSArray *trailingNavigationBarButtons = [self parseBarButtons:[RCTConvert NSArray:config[@"trailingNavigationBarButtons"]] templateId:templateId];
+        [mapTemplate setTrailingNavigationBarButtons:trailingNavigationBarButtons];
+    }
+
     if ([config objectForKey:@"mapButtons"]) {
         NSArray *mapButtons = [RCTConvert NSArray:config[@"mapButtons"]];
         NSMutableArray *result = [NSMutableArray array];


### PR DESCRIPTION
In the maptemplate, the leading and trailing buttons wouldn't update.  This completes the wiring to make those update on the MapTemplate.updateConfig call.