### PR TITLE
Cancel Navigation Wire Up on Typescript

### DIFF
--- a/src/templates/MapTemplate.ts
+++ b/src/templates/MapTemplate.ts
@@ -42,6 +42,7 @@ export interface MapTemplateConfig extends TemplateConfig {
   onPanBeganWithDirection?({ direction: string }): void;
   onPanEndedDirection?({ direction: string }): void;
   onSelectedPreviewForTrip?(e: { tripId: string; routeIndex: number }): void;
+  onDidCancelNavigation?(e:{}): void;
   onStartedTrip?(e: { tripId: string; routeIndex: number }): void;
 }
 
@@ -69,6 +70,7 @@ export class MapTemplate extends Template<MapTemplateConfig> {
       panBeganWithDirection: 'onPanBeganWithDirection',
       panEndedWithDirection: 'onPanEndedWithDirection',
       selectedPreviewForTrip: 'onSelectedPreviewForTrip',
+      didCancelNavigation: 'onDidCancelNavigation',
       startedTrip: 'onStartedTrip',
     };
   }


### PR DESCRIPTION
#4 of the carplay requirements states that the app must cancel navigation once the system sends the - mapTemplateDidCancelNavigation command. 

It was already pre-wired, but needed to be interfaced into the typescript side to work properly. 
