### PR TITLE
Fix Android Crashes

### DIFF
--- a/src/CarPlay.ts
+++ b/src/CarPlay.ts
@@ -1,4 +1,4 @@
-import { NativeEventEmitter, NativeModules } from 'react-native';
+import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
 import { ActionSheetTemplate } from './templates/ActionSheetTemplate';
 import { AlertTemplate } from './templates/AlertTemplate';
 import { ContactTemplate } from './templates/ContactTemplate';
@@ -48,6 +48,10 @@ class CarPlayInterface {
   private onDisconnectCallbacks = new Set<() => void>();
 
   constructor() {
+    if (Platform.OS != 'ios') {
+      return
+    }
+    
     this.emitter.addListener('didConnect', () => {
       this.connected = true;
       this.onConnectCallbacks.forEach(callback => {

--- a/src/CarPlay.ts
+++ b/src/CarPlay.ts
@@ -48,7 +48,7 @@ class CarPlayInterface {
   private onDisconnectCallbacks = new Set<() => void>();
 
   constructor() {
-    if (Platform.OS != 'ios') {
+    if (Platform.OS !== 'ios') {
       return
     }
     


### PR DESCRIPTION
Android crashes if you do anything regarding the `CarPlay` import. If you add a listener from 'CarPlay' the entire app will crash. 

This is a quick safety line that will keep the CarPlay library from initializing on Android if 'CarPlay' is accidentally used without a Platform check.  