### PR TITLE
Add max section and item count to list template

### DIFF
--- a/ios/RNCarPlay.m
+++ b/ios/RNCarPlay.m
@@ -521,6 +521,36 @@ RCT_EXPORT_METHOD(updateListTemplateItem:(NSString *)templateId config:(NSDictio
     }
 }
 
+RCT_EXPORT_METHOD(getMaximumListItemCount:(NSString *)templateId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    RNCPStore *store = [RNCPStore sharedManager];
+    CPTemplate *template = [store findTemplateById:templateId];
+    if (template) {
+        CPListTemplate *listTemplate = (CPListTemplate*) template;
+        NSInteger count = CPListTemplate.maximumItemCount;
+        resolve(@(count));
+    } else {
+        NSLog(@"Failed to find template %@", template);
+        reject(@"template_not_found", @"Template not found in store", nil);
+    }
+}
+
+RCT_EXPORT_METHOD(getMaximumListSectionCount:(NSString *)templateId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    RNCPStore *store = [RNCPStore sharedManager];
+    CPTemplate *template = [store findTemplateById:templateId];
+    if (template) {
+        CPListTemplate *listTemplate = (CPListTemplate*) template;
+        NSInteger count = CPListTemplate.maximumSectionCount;
+        resolve(@(count));
+    } else {
+        NSLog(@"Failed to find template %@", template);
+        reject(@"template_not_found", @"Template not found in store", nil);
+    }
+}
+
 RCT_EXPORT_METHOD(updateMapTemplateConfig:(NSString *)templateId config:(NSDictionary*)config) {
     CPTemplate *template = [[RNCPStore sharedManager] findTemplateById:templateId];
     if (template) {

--- a/ios/RNCarPlay.m
+++ b/ios/RNCarPlay.m
@@ -528,8 +528,7 @@ RCT_EXPORT_METHOD(getMaximumListItemCount:(NSString *)templateId
     CPTemplate *template = [store findTemplateById:templateId];
     if (template) {
         CPListTemplate *listTemplate = (CPListTemplate*) template;
-        NSInteger count = CPListTemplate.maximumItemCount;
-        resolve(@(count));
+        resolve(@(CPListTemplate.maximumItemCount));
     } else {
         NSLog(@"Failed to find template %@", template);
         reject(@"template_not_found", @"Template not found in store", nil);
@@ -543,8 +542,7 @@ RCT_EXPORT_METHOD(getMaximumListSectionCount:(NSString *)templateId
     CPTemplate *template = [store findTemplateById:templateId];
     if (template) {
         CPListTemplate *listTemplate = (CPListTemplate*) template;
-        NSInteger count = CPListTemplate.maximumSectionCount;
-        resolve(@(count));
+        resolve(@(CPListTemplate.maximumSectionCount));
     } else {
         NSLog(@"Failed to find template %@", template);
         reject(@"template_not_found", @"Template not found in store", nil);

--- a/src/templates/ListTemplate.ts
+++ b/src/templates/ListTemplate.ts
@@ -85,4 +85,12 @@ export class ListTemplate extends Template<ListTemplateConfig> {
   public updateListTemplateItem = (config: ListItemUpdate) => {
     return CarPlay.bridge.updateListTemplateItem(this.id, this.parseConfig(config));
   };
+
+  public getMaximumListItemCount () {
+    return CarPlay.bridge.getMaximumListItemCount(this.id);
+  }
+
+  public getMaximumListSectionCount () {
+    return CarPlay.bridge.getMaximumListSectionCount(this.id);
+  }
 }


### PR DESCRIPTION
- Adds a couple of methods to get `maximumSectionCount` and `maximumItemCount` of the list template. These properties' value is dependent on any user interface limits that the vehicle imposes.
- Comes in handy when prioritizing what to show to the user if your data-list is longer than the maximum limit of the template.