### PR TITLE
Fix an issue with Objective-C++ ("template" is reserved in c++)

### DIFF
--- a/ios/RNCPStore.h
+++ b/ios/RNCPStore.h
@@ -11,7 +11,7 @@
 
 + (id)sharedManager;
 - (CPTemplate*) findTemplateById: (NSString*)templateId;
-- (NSString*) setTemplate:(NSString*)templateId template:(CPTemplate*)template;
+- (NSString*) setTemplate:(NSString*)templateId template:(CPTemplate*)carPlayTemplate;
 - (CPTrip*) findTripById: (NSString*)tripId;
 - (NSString*) setTrip:(NSString*)tripId trip:(CPTrip*)trip;
 - (CPNavigationSession*) findNavigationSessionById:(NSString*)navigationSessionId;

--- a/ios/RNCPStore.m
+++ b/ios/RNCPStore.m
@@ -42,8 +42,8 @@
     return [_templatesStore objectForKey:templateId];
 }
 
-- (NSString*) setTemplate:(NSString*)templateId template:(CPTemplate*)template {
-    [_templatesStore setObject:template forKey:templateId];
+- (NSString*) setTemplate:(NSString*)templateId template:(CPTemplate*)carPlayTemplate {
+    [_templatesStore setObject:carPlayTemplate forKey:templateId];
     return templateId;
 }
 


### PR DESCRIPTION
C++ has the concept of templates, and therefore we need to rename "template" to something else in order to support React Native's New Architecture. (RN 0.68+)

This closes #103