### PR TITLE
implemented passing of window layout information to the JS side

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -203,7 +203,7 @@ PODS:
     - React-jsi (= 0.64.2)
     - React-perflogger (= 0.64.2)
   - React-jsinspector (0.64.2)
-  - react-native-carplay (2.0.0):
+  - react-native-carplay (2.1.0):
     - React
   - react-native-safe-area-context (3.1.9):
     - React-Core
@@ -397,7 +397,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: e686045572151edef46010a6f819ade377dfeb4b
-  FBReactNativeSpec: 7a1527832c44ba429e848ed271467423857654d1
+  FBReactNativeSpec: b4886934c105f3a27eca969d0c2420708cd9f237
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 6d3e854f0e7260a648badd0d44fc364bc9da9728
@@ -410,7 +410,7 @@ SPEC CHECKSUMS:
   React-jsi: 67747b9722f6dab2ffe15b011bcf6b3f2c3f1427
   React-jsiexecutor: 80c46bd381fd06e418e0d4f53672dc1d1945c4c3
   React-jsinspector: cc614ec18a9ca96fd275100c16d74d62ee11f0ae
-  react-native-carplay: 4105326f4eb8f953f21546bad9a6afb307e995d0
+  react-native-carplay: c95ba25269364772d115c61c4554ed476559d318
   react-native-safe-area-context: b6e0e284002381d2ff29fa4fff42b4d8282e3c94
   React-perflogger: 25373e382fed75ce768a443822f07098a15ab737
   React-RCTActionSheet: af7796ba49ffe4ca92e7277a5d992d37203f7da5
@@ -432,4 +432,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: b15f6218223a4a66bd2b4198678a5c02d7041bae
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.12.0

--- a/ios/RNCarPlay.m
+++ b/ios/RNCarPlay.m
@@ -10,6 +10,10 @@
 @synthesize selectedResultBlock;
 @synthesize isNowPlayingActive;
 
++ (NSDictionary *) getConnectedWindowInformation: (CPWindow *) window {
+    return @{@"width": @(window.bounds.size.width), @"height": @(window.bounds.size.height), @"scale": @(window.screen.scale)}
+}
+
 + (void) connectWithInterfaceController:(CPInterfaceController*)interfaceController window:(CPWindow*)window {
     RNCPStore * store = [RNCPStore sharedManager];
     store.interfaceController = interfaceController;
@@ -18,7 +22,7 @@
 
     RNCarPlay *cp = [RNCarPlay allocWithZone:nil];
     if (cp.bridge) {
-        [cp sendEventWithName:@"didConnect" body:@{}];
+        [cp sendEventWithName:@"didConnect" body:[self getConnectedWindowInformation:window]];
     }
 }
 
@@ -117,7 +121,7 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(checkForConnection) {
     RNCPStore *store = [RNCPStore sharedManager];
     if ([store isConnected]) {
-        [self sendEventWithName:@"didConnect" body:@{}];
+        [self sendEventWithName:@"didConnect" body:[RNCarPlay getConnectedWindowInformation: store.window]];
     }
 }
 

--- a/src/CarPlay.ts
+++ b/src/CarPlay.ts
@@ -25,6 +25,15 @@ type PushableTemplates =
   | NowPlayingTemplate;
 type PresentableTemplates = AlertTemplate | ActionSheetTemplate | VoiceControlTemplate;
 
+type WindowInformation = {
+  width: number,
+  height: number,
+  scale: number,
+}
+
+type OnConnectCallback = (window: WindowInformation) => void
+type OnDisconnectCallback = () => void
+
 /**
  * A controller that manages all user interface elements appearing on your map displayed on the CarPlay screen.
  */
@@ -44,18 +53,18 @@ class CarPlayInterface {
    */
   public emitter = new NativeEventEmitter(RNCarPlay);
 
-  private onConnectCallbacks = new Set<() => void>();
-  private onDisconnectCallbacks = new Set<() => void>();
+  private onConnectCallbacks = new Set<OnConnectCallback>();
+  private onDisconnectCallbacks = new Set<OnDisconnectCallback>();
 
   constructor() {
     if (Platform.OS !== 'ios') {
       return;
     }
 
-    this.emitter.addListener('didConnect', () => {
+    this.emitter.addListener('didConnect', (window: WindowInformation) => {
       this.connected = true;
       this.onConnectCallbacks.forEach(callback => {
-        callback();
+        callback(window);
       });
     });
     this.emitter.addListener('didDisconnect', () => {
@@ -73,22 +82,22 @@ class CarPlayInterface {
   /**
    * Fired when CarPlay is connected to the device.
    */
-  public registerOnConnect = (callback: () => void) => {
+  public registerOnConnect = (callback: OnConnectCallback) => {
     this.onConnectCallbacks.add(callback);
   };
 
-  public unregisterOnConnect = (callback: () => void) => {
+  public unregisterOnConnect = (callback: OnConnectCallback) => {
     this.onConnectCallbacks.delete(callback);
   };
 
   /**
    * Fired when CarPlay is disconnected from the device.
    */
-  public registerOnDisconnect = (callback: () => void) => {
+  public registerOnDisconnect = (callback: OnDisconnectCallback) => {
     this.onDisconnectCallbacks.add(callback);
   };
 
-  public unregisterOnDisconnect = (callback: () => void) => {
+  public unregisterOnDisconnect = (callback: OnDisconnectCallback) => {
     this.onDisconnectCallbacks.delete(callback);
   };
 


### PR DESCRIPTION
### What has changed?
Right now there is no way to access the information about the connected HeadUnit display. The ReactNative's dimension API gives the information about the phone, not the HeadUnit. The layout information is important when we want to implement animations when using a custom map component.

This PR exposes that information through the `didConnect` event. The exposed property are `width`, `height`, and `scale`.

**I'm not a professional Objective-C developer. Please let me know if there is something wrong with the implementation.**