### PR TITLE
fixed template config being out of sync

### DIFF
--- a/packages/react-native-carplay/src/templates/InformationTemplate.ts
+++ b/packages/react-native-carplay/src/templates/InformationTemplate.ts
@@ -31,10 +31,12 @@ export class InformationTemplate extends Template<InformationTemplateConfig> {
   }
 
   public updateInformationTemplateItems = (items: InformationItem[]) => {
+    this.config.items = items
     return CarPlay.bridge.updateInformationTemplateItems(this.id, this.parseConfig(items));
   };
 
   public updateInformationTemplateActions = (actions: InformationAction[]) => {
+    this.config.actions = actions
     return CarPlay.bridge.updateInformationTemplateActions(this.id, this.parseConfig(actions));
   };
 }

--- a/packages/react-native-carplay/src/templates/InformationTemplate.ts
+++ b/packages/react-native-carplay/src/templates/InformationTemplate.ts
@@ -31,12 +31,12 @@ export class InformationTemplate extends Template<InformationTemplateConfig> {
   }
 
   public updateInformationTemplateItems = (items: InformationItem[]) => {
-    this.config.items = items
+    this.config.items = items;
     return CarPlay.bridge.updateInformationTemplateItems(this.id, this.parseConfig(items));
   };
 
   public updateInformationTemplateActions = (actions: InformationAction[]) => {
-    this.config.actions = actions
+    this.config.actions = actions;
     return CarPlay.bridge.updateInformationTemplateActions(this.id, this.parseConfig(actions));
   };
 }

--- a/packages/react-native-carplay/src/templates/ListTemplate.ts
+++ b/packages/react-native-carplay/src/templates/ListTemplate.ts
@@ -98,12 +98,12 @@ export class ListTemplate extends Template<ListTemplateConfig> {
   }
 
   public updateSections = (sections: ListSection[]) => {
-    this.config.sections = sections
+    this.config.sections = sections;
     return CarPlay.bridge.updateListTemplateSections(this.id, this.parseConfig(sections));
   };
 
   public updateListTemplateItem = (config: ListItemUpdate) => {
-    this.config.sections[config.sectionIndex].items[config.itemIndex] = config
+    this.config.sections[config.sectionIndex].items[config.itemIndex] = config;
     return CarPlay.bridge.updateListTemplateItem(this.id, this.parseConfig(config));
   };
 

--- a/packages/react-native-carplay/src/templates/ListTemplate.ts
+++ b/packages/react-native-carplay/src/templates/ListTemplate.ts
@@ -98,10 +98,12 @@ export class ListTemplate extends Template<ListTemplateConfig> {
   }
 
   public updateSections = (sections: ListSection[]) => {
+    this.config.sections = sections
     return CarPlay.bridge.updateListTemplateSections(this.id, this.parseConfig(sections));
   };
 
   public updateListTemplateItem = (config: ListItemUpdate) => {
+    this.config.sections[config.sectionIndex].items[config.itemIndex] = config
     return CarPlay.bridge.updateListTemplateItem(this.id, this.parseConfig(config));
   };
 

--- a/packages/react-native-carplay/src/templates/MapTemplate.ts
+++ b/packages/react-native-carplay/src/templates/MapTemplate.ts
@@ -119,10 +119,12 @@ export class MapTemplate extends Template<MapTemplateConfig> {
    * Update MapTemplate configuration
    */
   public updateConfig(config: MapTemplateConfig) {
+    this.config = config
     CarPlay.bridge.updateMapTemplateConfig(this.id, this.parseConfig(config));
   }
 
   public updateMapButtons(mapButtons: MapButton[]) {
+    this.config.mapButtons = mapButtons
     CarPlay.bridge.updateMapTemplateMapButtons(this.id, this.parseConfig(mapButtons));
   }
 

--- a/packages/react-native-carplay/src/templates/MapTemplate.ts
+++ b/packages/react-native-carplay/src/templates/MapTemplate.ts
@@ -119,12 +119,12 @@ export class MapTemplate extends Template<MapTemplateConfig> {
    * Update MapTemplate configuration
    */
   public updateConfig(config: MapTemplateConfig) {
-    this.config = config
+    this.config = config;
     CarPlay.bridge.updateMapTemplateConfig(this.id, this.parseConfig(config));
   }
 
   public updateMapButtons(mapButtons: MapButton[]) {
-    this.config.mapButtons = mapButtons
+    this.config.mapButtons = mapButtons;
     CarPlay.bridge.updateMapTemplateMapButtons(this.id, this.parseConfig(mapButtons));
   }
 

--- a/packages/react-native-carplay/src/templates/TabBarTemplate.ts
+++ b/packages/react-native-carplay/src/templates/TabBarTemplate.ts
@@ -46,7 +46,7 @@ export class TabBarTemplate extends Template<TabBarTemplateConfig> {
   }
 
   public updateTemplates = (config: TabBarTemplateConfig) => {
-    this.config = config
+    this.config = config;
     return CarPlay.bridge.updateTabBarTemplates(this.id, this.parseConfig(config));
   };
 }

--- a/packages/react-native-carplay/src/templates/TabBarTemplate.ts
+++ b/packages/react-native-carplay/src/templates/TabBarTemplate.ts
@@ -46,6 +46,7 @@ export class TabBarTemplate extends Template<TabBarTemplateConfig> {
   }
 
   public updateTemplates = (config: TabBarTemplateConfig) => {
+    this.config = config
     return CarPlay.bridge.updateTabBarTemplates(this.id, this.parseConfig(config));
   };
 }


### PR DESCRIPTION
## What has changed?

Whenever we update the config of a template and try to read it back, the config doesn't update. It returns the initial config that was used when creating the template.

This PR keeps the config of the template synced whenever it is updated. I think I have covered all the cases. Let me know if I missed something. 