### PR TITLE
feat: load ListItem images asynchronously

### DIFF
--- a/packages/react-native-carplay/ios/RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RNCarPlay.m
@@ -963,14 +963,20 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
     NSMutableArray *_items = [NSMutableArray array];
     int index = startIndex;
     for (NSDictionary *item in items) {
-        BOOL _showsDisclosureIndicator = [item objectForKey:@"showsDisclosureIndicator"];
+        BOOL _showsDisclosureIndicator = [[item objectForKey:@"showsDisclosureIndicator"] isEqualToNumber:[NSNumber numberWithInt:1]];
         NSString *_detailText = [item objectForKey:@"detailText"];
         NSString *_text = [item objectForKey:@"text"];
         UIImage *_image = [RCTConvert UIImage:[item objectForKey:@"image"]];
         if (item[@"imgUrl"]) {
             _image = [[UIImage alloc] initWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:[RCTConvert NSString:item[@"imgUrl"]]]]];
         }
-        CPListItem *_item = [[CPListItem alloc] initWithText:_text detailText:_detailText image:_image showsDisclosureIndicator:_showsDisclosureIndicator];
+        CPListItem *_item;
+        if (@available(iOS 14.0, *)) {
+            CPListItemAccessoryType accessoryType = _showsDisclosureIndicator ? CPListItemAccessoryTypeDisclosureIndicator : CPListItemAccessoryTypeNone;
+            _item = [[CPListItem alloc] initWithText:_text detailText:_detailText image:_image accessoryImage:nil accessoryType:accessoryType];
+        } else {
+            _item = [[CPListItem alloc] initWithText:_text detailText:_detailText image:_image showsDisclosureIndicator:_showsDisclosureIndicator];
+        }
         if ([item objectForKey:@"isPlaying"]) {
             [_item setPlaying:[RCTConvert BOOL:[item objectForKey:@"isPlaying"]]];
         }

--- a/packages/react-native-carplay/src/interfaces/ListItem.ts
+++ b/packages/react-native-carplay/src/interfaces/ListItem.ts
@@ -13,11 +13,11 @@ export interface ListItem {
    */
   detailText?: string;
   /**
-   * The image displayed on the leading edge of the list item cell.
+   * Image from file system displayed on the leading edge of the list item cell.
    */
   image?: ImageSourcePropType;
   /**
-   * The image from file system displayed on the leading edge of the list item cell.
+   * Url for image displayed on the leading edge of the list item cell.
    */
   imgUrl?: null;
   /**


### PR DESCRIPTION
["Synchronous image loading is generally a bad idea for performance reasons."](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Base/RCTConvert.h#L158)
This changes image loading to asynchronous via a NSURLSessionDataTask.

Also: Fix inline documentation for ListItem images

Includes/based on https://github.com/birkir/react-native-carplay/pull/142