### PR TITLE
Fix iOS createTemplate callback

### DIFF
--- a/packages/react-native-carplay/ios/RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RNCarPlay.m
@@ -186,7 +186,7 @@ RCT_EXPORT_METHOD(checkForConnection) {
     }
 }
 
-RCT_EXPORT_METHOD(createTemplate:(NSString *)templateId config:(NSDictionary*)config) {
+RCT_EXPORT_METHOD(createTemplate:(NSString *)templateId config:(NSDictionary*)config callback:(id)callback) {
     // Get the shared instance of the RNCPStore class
     RNCPStore *store = [RNCPStore sharedManager];
 


### PR DESCRIPTION
Since Android Auto support was added, the `callback` parameter is always passed to `createTemplate()`. This breaks iOS because React Native is expecting two function arguments.

This PR brings parity between iOS and Android.

This would close #166