### PR TITLE
Fix iOS-app crashing when connecting an external display

### DIFF
--- a/apps/example/ios/PhoneScene.swift
+++ b/apps/example/ios/PhoneScene.swift
@@ -5,6 +5,11 @@ import SwiftUI
 class PhoneSceneDelegate: UIResponder, UIWindowSceneDelegate {
   var window: UIWindow?
   func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    
+    if session.role != .windowApplication {
+      return
+    }
+    
     guard let appDelegate = (UIApplication.shared.delegate as? AppDelegate) else { return }
     guard let windowScene = (scene as? UIWindowScene) else { return }
 


### PR DESCRIPTION
External display connection invokes `scene:willConnectTo:options` again with the session role `.windowExternalDisplayNonInteractive`:https://developer.apple.com/documentation/uikit/windows_and_screens/presenting_content_on_a_connected_display

This needs to be explicitly handled or rejected, otherwise the app crashes with the error:
_Terminating app due to uncaught exception 'UIViewControllerHierarchyInconsistency', reason: 'A view can only be associated with at most one view controller at a time!'_