### PR TITLE
added full screen support on CarPlay Map template

### DIFF
--- a/packages/react-native-carplay/ios/RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RNCarPlay.m
@@ -1,4 +1,5 @@
 #import "RNCarPlay.h"
+#import "RNCarPlayViewController.h"
 #import <React/RCTConvert.h>
 #import <React/RCTRootView.h>
 
@@ -44,7 +45,7 @@
     RNCarPlay *cp = [RNCarPlay allocWithZone:nil];
     RNCPStore *store = [RNCPStore sharedManager];
     [store setConnected:false];
-    [[store.window subviews] makeObjectsPerformSelector:@selector(removeFromSuperview)];
+    store.window.rootViewController = nil;
 
     if (cp.bridge) {
         [cp sendEventWithName:@"didDisconnect" body:@{}];
@@ -887,9 +888,8 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
 
     if ([config objectForKey:@"render"]) {
         RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:templateId initialProperties:@{}];
-        [rootView setFrame:store.window.frame];
-        [[store.window subviews] makeObjectsPerformSelector:@selector(removeFromSuperview)];
-        [store.window addSubview:rootView];
+        RNCarPlayViewController *viewController = [[RNCarPlayViewController alloc] initWithRootView:rootView];
+        store.window.rootViewController = viewController;
     }
 }
 

--- a/packages/react-native-carplay/ios/RNCarPlayViewController.h
+++ b/packages/react-native-carplay/ios/RNCarPlayViewController.h
@@ -1,0 +1,10 @@
+//
+//  RNCarPlayViewController.h
+//  Created by Susan Thapa on 27/02/2024.
+//
+#import <UIKit/UIKit.h>
+#import <React/RCTRootView.h>
+
+@interface RNCarPlayViewController : UIViewController
+- (instancetype)initWithRootView:(RCTRootView *)rootView;
+@end

--- a/packages/react-native-carplay/ios/RNCarPlayViewController.m
+++ b/packages/react-native-carplay/ios/RNCarPlayViewController.m
@@ -1,0 +1,50 @@
+//
+//  RNCarPlayViewController.m
+//  react-native-carplay
+//
+//  Created by Susan Thapa on 27/02/2024.
+//
+
+#import <Foundation/Foundation.h>
+#import "RNCarPlayViewController.h"
+#import <React/RCTRootView.h>
+
+@interface RNCarPlayViewController ()
+
+@property (nonatomic, strong) RCTRootView *rootView;
+
+@end
+
+@implementation RNCarPlayViewController
+
+- (instancetype)initWithRootView:(RCTRootView *)rootView {
+    self = [super init];
+    if (self) {
+        _rootView = rootView;
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.translatesAutoresizingMaskIntoConstraints = false;
+    if (self.rootView) {
+        self.rootView.translatesAutoresizingMaskIntoConstraints = false;
+        self.rootView.frame = self.view.bounds;
+        [self.view addSubview:self.rootView];
+        
+        [NSLayoutConstraint activateConstraints:@[
+            [self.rootView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+            [self.rootView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+            [self.rootView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+            [self.rootView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+        ]];
+    }
+}
+
+- (void)viewWillLayoutSubviews {
+    [super viewWillLayoutSubviews];
+    self.rootView.frame = self.view.bounds;
+}
+
+@end

--- a/packages/react-native-carplay/src/CarPlay.ts
+++ b/packages/react-native-carplay/src/CarPlay.ts
@@ -1,4 +1,10 @@
-import { ImageSourcePropType, NativeEventEmitter, NativeModule, NativeModules, Platform } from 'react-native';
+import {
+  ImageSourcePropType,
+  NativeEventEmitter,
+  NativeModule,
+  NativeModules,
+  Platform,
+} from 'react-native';
 import { ActionSheetTemplate } from './templates/ActionSheetTemplate';
 import { AlertTemplate } from './templates/AlertTemplate';
 import { ContactTemplate } from './templates/ContactTemplate';


### PR DESCRIPTION
### What has changed?
- Added full-screen support for the CarPlay Map template.

### Solution description
I have switched to using the Root ViewController to render the React view and used the auto layout to properly layout the view. 

### Before
https://github.com/birkir/react-native-carplay/assets/33973551/d8600f91-38c2-479a-9f57-e406dd4b2a22

### After
https://github.com/birkir/react-native-carplay/assets/33973551/6bcb06ee-2bdf-4a31-be5f-993188e16fc5

