### PR TITLE
Implement image button in CarPlay CPNowPlayingTemplate.

### DIFF
--- a/packages/react-native-carplay/ios/RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RNCarPlay.m
@@ -289,11 +289,23 @@ RCT_EXPORT_METHOD(createTemplate:(NSString *)templateId config:(NSDictionary*)co
             NSDictionary *body = @{@"templateId":templateId, @"id": _button[@"id"] };
             Class buttonClass = buttonTypeMapping[buttonType];
             if (buttonClass) {
-                CPNowPlayingButton *button = [[buttonClass alloc] initWithHandler:^(__kindof CPNowPlayingButton * _Nonnull) {
-                    if (self->hasListeners) {
-                        [self sendEventWithName:@"buttonPressed" body:body];
-                    }
-                }];
+                CPNowPlayingButton *button;
+                
+                if ([buttonType isEqualToString:@"image"]) {
+                    UIImage *_image = [RCTConvert UIImage:[_button objectForKey:@"image"]];
+                    button = [[CPNowPlayingImageButton alloc] initWithImage:_image handler:^(__kindof CPNowPlayingImageButton * _Nonnull) {
+                        if (self->hasListeners) {
+                            [self sendEventWithName:@"buttonPressed" body:body];
+                        }
+                    }];
+                } else {
+                    button = [[buttonClass alloc] initWithHandler:^(__kindof CPNowPlayingButton * _Nonnull) {
+                        if (self->hasListeners) {
+                            [self sendEventWithName:@"buttonPressed" body:body];
+                        }
+                    }];
+                }
+                
                 [buttons addObject:button];
             }
         }

--- a/packages/react-native-carplay/src/CarPlay.ts
+++ b/packages/react-native-carplay/src/CarPlay.ts
@@ -1,4 +1,10 @@
-import { ImageSourcePropType, NativeEventEmitter, NativeModule, NativeModules, Platform } from 'react-native';
+import {
+  ImageSourcePropType,
+  NativeEventEmitter,
+  NativeModule,
+  NativeModules,
+  Platform,
+} from 'react-native';
 import { ActionSheetTemplate } from './templates/ActionSheetTemplate';
 import { AlertTemplate } from './templates/AlertTemplate';
 import { ContactTemplate } from './templates/ContactTemplate';


### PR DESCRIPTION
Fixes #171 
The typings were already there, but RNCarPlay.m did not use the image property of the button of the CPNowPlayingTemplate.
This PR implements this, so the image will be rendered.