### PR TITLE
fixed incorrect set function for focused image

### DIFF
--- a/packages/react-native-carplay/ios/RCTConvert+RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RCTConvert+RNCarPlay.m
@@ -44,7 +44,7 @@ RCT_ENUM_CONVERTER(CPAssistantCellActionType, (@{
     }
 
     if ([json objectForKey:@"focusedImage"]) {
-        [mapButton setImage:[RCTConvert UIImage:json[@"focusedImage"]]];
+        [mapButton setFocusedImage:[RCTConvert UIImage:json[@"focusedImage"]]];
     }
 
     if ([json objectForKey:@"disabled"]) {


### PR DESCRIPTION
Fix for incorrect `setImage` passed instead of `setFocusedImage` which was rendering incorrect image during focus.