### PR TITLE
Fix missing even didPressMenuItem

### DIFF
--- a/packages/react-native-carplay/ios/RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RNCarPlay.m
@@ -68,6 +68,7 @@ RCT_EXPORT_MODULE();
     return @[
         @"didConnect",
         @"didDisconnect",
+        @"didPressMenuItem",
         // interface
         @"barButtonPressed",
         @"backButtonPressed",


### PR DESCRIPTION
Trivial fix to prevent error reported against "didPressMenuItem" on iOS.