### PR TITLE
Feat/improved list templates

### DIFF
--- a/packages/react-native-carplay/ios/RNCPStore.h
+++ b/packages/react-native-carplay/ios/RNCPStore.h
@@ -8,6 +8,7 @@
 
 @property (nonatomic, retain) CPInterfaceController *interfaceController;
 @property (nonatomic, retain) CPWindow *window;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableArray<CPListItem *> *> *itemsStore;
 
 + (id)sharedManager;
 - (CPTemplate*) findTemplateById: (NSString*)templateId;

--- a/packages/react-native-carplay/ios/RNCPStore.m
+++ b/packages/react-native-carplay/ios/RNCPStore.m
@@ -4,6 +4,7 @@
     NSMutableDictionary* _templatesStore;
     NSMutableDictionary* _navigationSessionsStore;
     NSMutableDictionary* _tripsStore;
+    NSMutableDictionary* _itemsStore;
     Boolean _connected;
 }
 
@@ -15,6 +16,7 @@
         _templatesStore = [[NSMutableDictionary alloc] init];
         _navigationSessionsStore = [[NSMutableDictionary alloc] init];
         _tripsStore = [[NSMutableDictionary alloc] init];
+        _itemsStore = [[NSMutableDictionary alloc] init];
         _connected = false;
     }
 

--- a/packages/react-native-carplay/ios/RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RNCarPlay.m
@@ -159,7 +159,7 @@ RCT_EXPORT_MODULE();
     UIGraphicsImageRendererFormat *renderFormat = [UIGraphicsImageRendererFormat defaultFormat];
     renderFormat.opaque = NO;
     UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size format:renderFormat];
-    
+
     UIImage *resizedImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
         [image drawInRect:CGRectMake(0, 0, size.width, size.height)];
     }];
@@ -168,7 +168,7 @@ RCT_EXPORT_MODULE();
 
 - (void)updateItemImageWithURL:(CPListItem *)item imgUrl:(NSString *)imgUrlString {
     NSURL *imgUrl = [NSURL URLWithString:imgUrlString];
-    
+
     NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:imgUrl completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         if (data) {
             UIImage *image = [UIImage imageWithData:data];
@@ -182,25 +182,25 @@ RCT_EXPORT_MODULE();
     [task resume];
 }
 
-- (void)updateListRowItemImageWithURL:(CPListImageRowItem *)item imgUrl:(NSString *)imgUrlString index:(int)index {    
+- (void)updateListRowItemImageWithURL:(CPListImageRowItem *)item imgUrl:(NSString *)imgUrlString index:(int)index {
     NSURL *imgUrl = [NSURL URLWithString:imgUrlString];
-    
+
     NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:imgUrl completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         if (data) {
             UIImage *image = [UIImage imageWithData:data];
-            
+
             dispatch_async(dispatch_get_main_queue(), ^{
                 NSMutableArray* newImages = [item.gridImages mutableCopy];
-                
+
                 @try {
                     newImages[index] = image;
                 }
                 @catch (NSException *exception) {
                     // Best effort updating the array
                     NSLog(@"Failed to update images array of CPListImageRowItem");
-                }                
-                
-                [item updateImages:newImages];                
+                }
+
+                [item updateImages:newImages];
             });
         } else {
             NSLog(@"Failed to load image for CPListImageRowItem from URL: %@", imgUrl);
@@ -225,7 +225,7 @@ RCT_EXPORT_METHOD(createTemplate:(NSString *)templateId config:(NSDictionary*)co
     NSString *title = [RCTConvert NSString:config[@"title"]];
     NSArray *leadingNavigationBarButtons = [self parseBarButtons:[RCTConvert NSArray:config[@"leadingNavigationBarButtons"]] templateId:templateId];
     NSArray *trailingNavigationBarButtons = [self parseBarButtons:[RCTConvert NSArray:config[@"trailingNavigationBarButtons"]] templateId:templateId];
-    
+
     // Create a new CPTemplate object
     CPTemplate *carPlayTemplate = [[CPTemplate alloc] init];
 
@@ -304,7 +304,7 @@ RCT_EXPORT_METHOD(createTemplate:(NSString *)templateId config:(NSDictionary*)co
         [nowPlayingTemplate setUpNextButtonEnabled:[RCTConvert BOOL:config[@"upNextButtonEnabled"]]];
         NSMutableArray<CPNowPlayingButton *> *buttons = [NSMutableArray new];
         NSArray<NSDictionary*> *_buttons = [RCTConvert NSDictionaryArray:config[@"buttons"]];
-        
+
         NSDictionary *buttonTypeMapping = @{
             @"shuffle": CPNowPlayingShuffleButton.class,
             @"add-to-library": CPNowPlayingAddToLibraryButton.class,
@@ -313,14 +313,14 @@ RCT_EXPORT_METHOD(createTemplate:(NSString *)templateId config:(NSDictionary*)co
             @"repeat": CPNowPlayingRepeatButton.class,
             @"image": CPNowPlayingImageButton.class
         };
-        
+
         for (NSDictionary *_button in _buttons) {
             NSString *buttonType = [RCTConvert NSString:_button[@"type"]];
             NSDictionary *body = @{@"templateId":templateId, @"id": _button[@"id"] };
             Class buttonClass = buttonTypeMapping[buttonType];
             if (buttonClass) {
                 CPNowPlayingButton *button;
-                
+
                 if ([buttonType isEqualToString:@"image"]) {
                     UIImage *_image = [RCTConvert UIImage:[_button objectForKey:@"image"]];
                     button = [[CPNowPlayingImageButton alloc] initWithImage:_image handler:^(__kindof CPNowPlayingImageButton * _Nonnull) {
@@ -335,7 +335,7 @@ RCT_EXPORT_METHOD(createTemplate:(NSString *)templateId config:(NSDictionary*)co
                         }
                     }];
                 }
-                
+
                 [buttons addObject:button];
             }
         }
@@ -744,7 +744,7 @@ RCT_EXPORT_METHOD(getMaximumListItemImageSize:(NSString *)templateId
             @"width": @(CPListItem.maximumImageSize.width),
             @"height": @(CPListItem.maximumImageSize.height)
         };
-        resolve(sizeDict);        
+        resolve(sizeDict);
     } else {
         NSLog(@"Failed to find template %@", template);
         reject(@"template_not_found", @"Template not found in store", nil);
@@ -790,7 +790,7 @@ RCT_EXPORT_METHOD(getMaximumListImageRowItemImageSize:(NSString *)templateId
             @"width": @(CPListImageRowItem.maximumImageSize.width),
             @"height": @(CPListImageRowItem.maximumImageSize.height)
         };
-        resolve(sizeDict);    
+        resolve(sizeDict);
     } else {
         NSLog(@"Failed to find template %@", template);
         reject(@"template_not_found", @"Template not found in store", nil);
@@ -939,7 +939,7 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
     else {
       [mapTemplate setGuidanceBackgroundColor:UIColor.systemGray5Color];
     }
-    
+
     if ([config objectForKey:@"tripEstimateStyle"]) {
         [mapTemplate setTripEstimateStyle:[RCTConvert CPTripEstimateStyle:config[@"tripEstimateStyle"]]];
     }
@@ -951,7 +951,7 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
         NSArray *leadingNavigationBarButtons = [self parseBarButtons:[RCTConvert NSArray:config[@"leadingNavigationBarButtons"]] templateId:templateId];
         [mapTemplate setLeadingNavigationBarButtons:leadingNavigationBarButtons];
     }
-  
+
     if ([config objectForKey:@"trailingNavigationBarButtons"]){
         NSArray *trailingNavigationBarButtons = [self parseBarButtons:[RCTConvert NSArray:config[@"trailingNavigationBarButtons"]] templateId:templateId];
         [mapTemplate setTrailingNavigationBarButtons:trailingNavigationBarButtons];
@@ -1084,10 +1084,10 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
         NSString *_detailText = [item objectForKey:@"detailText"];
         NSString *_text = [item objectForKey:@"text"];
         NSObject *_imageObj = [item objectForKey:@"image"];
-        
+
         NSArray *_imageItems = [item objectForKey:@"images"];
         NSArray *_imageUrls = [item objectForKey:@"imgUrls"];
-        
+
         if (_imageItems == nil && _imageUrls == nil) {
             UIImage *_image = [RCTConvert UIImage:_imageObj];
             CPListItem *_item;
@@ -1109,7 +1109,7 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
         } else {
             // parse images
             NSMutableArray * _images = [NSMutableArray array];
-            
+
             if (_imageItems != nil) {
                 NSArray* slicedArray = [_imageItems subarrayWithRange:NSMakeRange(0, MIN(CPMaximumNumberOfGridImages, _imageItems.count))];
 
@@ -1119,7 +1119,7 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
                 }
             }
             if (@available(iOS 14.0, *)) {
-                
+
                 CPListImageRowItem *_item;
                 if (_images.count > 0)
                 {
@@ -1129,22 +1129,22 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
                 {
                     // Show only as much images as allowed.
                     NSArray* _slicedArray = [_imageUrls subarrayWithRange:NSMakeRange(0, MIN(CPMaximumNumberOfGridImages, _imageUrls.count))];//
-                    
+
                     // create array with empty UI images, that will be replaced later
                     NSMutableArray *_imagesArray = [NSMutableArray arrayWithCapacity:_slicedArray.count];
                     for (NSUInteger i = 0; i < _slicedArray.count; i++) {
                         [_imagesArray addObject:[[UIImage alloc] init]];
                     }
                     _item = [[CPListImageRowItem alloc] initWithText:_text images:_imagesArray];
-                    
-                    
+
+
                     int _index = 0;
                     for (NSString* imgUrl in _slicedArray) {
                         [self updateListRowItemImageWithURL:_item imgUrl:imgUrl index:_index];
                         _index++;
                     }
                 }
-                
+
                 [_item setListImageRowHandler:^(CPListImageRowItem * _Nonnull item, NSInteger index, dispatch_block_t  _Nonnull completionBlock) {
                     // Find the current template
                     RNCPStore *store = [RNCPStore sharedManager];
@@ -1153,11 +1153,11 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
                         [self sendTemplateEventWithName:template name:@"didSelectListItemRowImage" json:@{ @"index": @(listIndex), @"imageIndex": @(index)}];
                     }
                 }];
-                    
+
                 [_item setUserInfo:@{ @"index": @(listIndex) }];
                 [_items addObject:_item];
             }
-            
+
         }
         listIndex = listIndex + 1;
     }
@@ -1170,7 +1170,7 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
     for (NSDictionary *item in items) {
         [_items addObject:[[CPInformationItem alloc] initWithTitle:item[@"title"] detail:item[@"detail"]]];
     }
-    
+
     return _items;
 }
 
@@ -1184,7 +1184,7 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
         }];
         [_actions addObject:_action];
     }
-    
+
     return _actions;
 }
 

--- a/packages/react-native-carplay/ios/RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RNCarPlay.m
@@ -697,6 +697,41 @@ RCT_EXPORT_METHOD(updateListTemplateItem:(NSString *)templateId config:(NSDictio
     }
 }
 
+RCT_EXPORT_METHOD(updateListItemById:(NSString *)itemId config:(NSDictionary*)config) {
+    RNCPStore *store = [RNCPStore sharedManager];
+    NSArray<CPListItem *> *items = store.itemsStore[itemId];
+
+    if (items == nil || items.count == 0) {
+        NSLog(@"No items found for itemId %@", itemId);
+        return;
+    }
+
+    for (CPListItem *item in items) {
+        if (config[@"imgUrl"]) {
+            NSString *imgUrlString = [RCTConvert NSString:config[@"imgUrl"]];
+            [self updateItemImageWithURL:item imgUrl:imgUrlString];
+        }
+        if (config[@"image"]) {
+            [item setImage:[RCTConvert UIImage:config[@"image"]]];
+        }
+        if (config[@"text"]) {
+            [item setText:[RCTConvert NSString:config[@"text"]]];
+        }
+        if (config[@"detailText"]) {
+            [item setDetailText:[RCTConvert NSString:config[@"detailText"]]];
+        }
+        if (config[@"isPlaying"]) {
+            [item setPlaying:[RCTConvert BOOL:config[@"isPlaying"]]];
+        }
+        if (@available(iOS 14.0, *) && config[@"playbackProgress"]) {
+            [item setPlaybackProgress:[RCTConvert CGFloat:config[@"playbackProgress"]]];
+        }
+        if (@available(iOS 14.0, *) && config[@"accessoryImage"]) {
+            [item setAccessoryImage:[RCTConvert UIImage:config[@"accessoryImage"]]];
+        }
+    }
+}
+
 RCT_EXPORT_METHOD(updateInformationTemplateItems:(NSString *)templateId items:(NSArray*)items) {
     RNCPStore *store = [RNCPStore sharedManager];
     CPTemplate *template = [store findTemplateById:templateId];

--- a/packages/react-native-carplay/ios/RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RNCarPlay.m
@@ -1120,6 +1120,10 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
             if ([item objectForKey:@"isPlaying"]) {
                 [_item setPlaying:[RCTConvert BOOL:[item objectForKey:@"isPlaying"]]];
             }
+            if (@available(iOS 14.0, *) && [item objectForKey:@"playbackProgress"]) {
+                CGFloat _playbackProgress = [RCTConvert CGFloat:[item objectForKey:@"playbackProgress"]];
+                [_item setPlaybackProgress: _playbackProgress];
+            }
             if (item[@"imgUrl"]) {
                 NSString *imgUrlString = [RCTConvert NSString:item[@"imgUrl"]];
                 [self updateItemImageWithURL:_item imgUrl:imgUrlString];

--- a/packages/react-native-carplay/ios/RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RNCarPlay.m
@@ -733,6 +733,26 @@ RCT_EXPORT_METHOD(getMaximumListItemCount:(NSString *)templateId
     }
 }
 
+RCT_EXPORT_METHOD(getTopTemplateId:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    RNCPStore *store = [RNCPStore sharedManager];
+    CPInterfaceController *interfaceController = [store interfaceController];
+    CPTemplate *topTemplate = interfaceController.topTemplate;
+
+    if (!topTemplate) {
+        reject(@"no_top_template", @"No top template is currently visible", nil);
+        return;
+    }
+
+    NSString *templateId = topTemplate.userInfo[@"templateId"];
+    if (!templateId) {
+        reject(@"no_template_id", @"Top template does not have a templateId in userInfo", nil);
+        return;
+    }
+
+    resolve(templateId);
+}
+
 RCT_EXPORT_METHOD(getMaximumListItemImageSize:(NSString *)templateId
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {

--- a/packages/react-native-carplay/ios/RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RNCarPlay.m
@@ -173,7 +173,9 @@ RCT_EXPORT_MODULE();
         if (data) {
             UIImage *image = [UIImage imageWithData:data];
             dispatch_async(dispatch_get_main_queue(), ^{
-                [item setImage:image];
+                if(image) {
+                  [item setImage:image];
+                }
             });
         } else {
             NSLog(@"Failed to load image from URL: %@", imgUrl);
@@ -193,7 +195,9 @@ RCT_EXPORT_MODULE();
                 NSMutableArray* newImages = [item.gridImages mutableCopy];
 
                 @try {
-                    newImages[index] = image;
+                    if(image) {
+                      newImages[index] = image;
+                    }
                 }
                 @catch (NSException *exception) {
                     // Best effort updating the array
@@ -293,7 +297,7 @@ RCT_EXPORT_METHOD(createTemplate:(NSString *)templateId config:(NSDictionary*)co
         if (![RCTConvert BOOL:config[@"backButtonHidden"]]) {
             if (@available(iOS 14.0, *)) {
                 CPBarButton *backButton = [[CPBarButton alloc] initWithTitle:@" Back" handler:^(CPBarButton * _Nonnull barButton) {
-                    if (hasListeners) {
+                    if (self->hasListeners) {
                         [self sendEventWithName:@"backButtonPressed" body:@{@"templateId":templateId}];
                     }
                     [self popTemplate:false];
@@ -676,9 +680,11 @@ RCT_EXPORT_METHOD(updateListTemplateSections:(NSString *)templateId sections:(NS
     CPTemplate *template = [store findTemplateById:templateId];
     if (template) {
         CPListTemplate *listTemplate = (CPListTemplate*) template;
-        [listTemplate updateSections:[self parseSections:sections templateId:templateId]];
+        NSArray *parsedSections = [self parseSections:sections templateId:templateId];
+
+        [listTemplate updateSections:parsedSections];
     } else {
-        NSLog(@"Failed to find template %@", template);
+        NSLog(@"Failed to find template %@", templateId);
     }
 }
 
@@ -1243,7 +1249,9 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
 
                 for (NSObject *imageObj in slicedArray){
                     UIImage *_image = [RCTConvert UIImage:imageObj];
-                    [_images addObject:_image];
+                    if (_image) {
+                      [_images addObject:_image];
+                    }
                 }
             }
             if (@available(iOS 14.0, *)) {

--- a/packages/react-native-carplay/ios/RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RNCarPlay.m
@@ -281,7 +281,6 @@ RCT_EXPORT_METHOD(createTemplate:(NSString *)templateId config:(NSDictionary*)co
                 listTemplate.emptyViewSubtitleVariants = [RCTConvert NSArray:config[@"emptyViewSubtitleVariants"]];
             }
         }
-        listTemplate.delegate = self;
         carPlayTemplate = listTemplate;
     }
     else if ([type isEqualToString:@"map"]) {
@@ -1142,6 +1141,17 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
 
         NSArray *_imageItems = [item objectForKey:@"images"];
         NSArray *_imageUrls = [item objectForKey:@"imgUrls"];
+        NSArray *_imageIds = [item objectForKey:@"imageIds"];
+
+        NSString *_itemId = [item objectForKey:@"id"];
+
+        if (_itemId == nil) {
+            _itemId = (id)[NSNull null];
+        }
+
+        if (_imageIds == nil) {
+            _imageIds = (id)[NSNull null];
+        }
 
         if (_imageItems == nil && _imageUrls == nil) {
             UIImage *_image = [RCTConvert UIImage:_imageObj];
@@ -1163,8 +1173,37 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
                 NSString *imgUrlString = [RCTConvert NSString:item[@"imgUrl"]];
                 [self updateItemImageWithURL:_item imgUrl:imgUrlString];
             }
-            [_item setUserInfo:@{ @"index": @(listIndex) }];
-            [_items addObject:_item];
+            [_item setUserInfo:@{
+              @"index": @(listIndex),
+              @"itemId": _itemId
+            }];
+
+            _item.handler = ^(CPListItem *selectedItem, void (^completionHandler)(void)) {
+                NSDictionary *payload = @{
+                  @"templateId": templateId,
+                  @"index": selectedItem.userInfo[@"index"],
+                  @"itemId": selectedItem.userInfo[@"itemId"]
+                };
+                if (self->hasListeners) {
+                  [self sendEventWithName:@"didSelectListItem" body:payload];
+                }
+                self.selectedResultBlock = completionHandler;
+            };
+            if (_itemId) {
+                RNCPStore *store = [RNCPStore sharedManager];
+                NSMutableArray *existing = store.itemsStore[_itemId];
+                if (existing == nil) {
+                    existing = [NSMutableArray array];
+                    store.itemsStore[_itemId] = existing;
+                }
+                [existing addObject:_item];
+            }
+
+            if (_item) {
+              [_items addObject:_item];
+            } else {
+              NSLog(@"The item was nil can't be created %@", item);
+            }
         } else {
             // parse images
             NSMutableArray * _images = [NSMutableArray array];
@@ -1204,17 +1243,68 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
                     }
                 }
 
+                [_item setUserInfo:@{
+                  @"index": @(listIndex),
+                  @"itemId": _itemId,
+                  @"imageIds": _imageIds
+                }];
+
                 [_item setListImageRowHandler:^(CPListImageRowItem * _Nonnull item, NSInteger index, dispatch_block_t  _Nonnull completionBlock) {
                     // Find the current template
                     RNCPStore *store = [RNCPStore sharedManager];
                     CPTemplate *template = [store findTemplateById:templateId];
+                    NSString *imageId = nil;
+
+                    id imageIdsObj = item.userInfo[@"imageIds"];
+                    if ([imageIdsObj isKindOfClass:[NSArray class]]) {
+                        NSArray *imageIds = (NSArray *)imageIdsObj;
+                        if (index < imageIds.count) {
+                            id candidate = imageIds[index];
+                            if ([candidate isKindOfClass:[NSString class]]) {
+                                imageId = candidate;
+                            }
+                        }
+                    }
+
+                    if (!imageId) {
+                        imageId = (NSString *)[NSNull null];
+                    }
+
                     if (template) {
-                        [self sendTemplateEventWithName:template name:@"didSelectListItemRowImage" json:@{ @"index": @(listIndex), @"imageIndex": @(index)}];
+                        NSMutableDictionary *payload = [@{
+                            @"index": @(listIndex),
+                            @"imageIndex": @(index),
+                            @"itemId": item.userInfo[@"itemId"],
+                        } mutableCopy];
+
+                        if (![imageId isKindOfClass:[NSNull class]]) {
+                            payload[@"imageId"] = imageId;
+                        }
+
+                        [self sendTemplateEventWithName:template
+                            name:@"didSelectListItemRowImage"
+                            json:payload];
                     }
                 }];
 
-                [_item setUserInfo:@{ @"index": @(listIndex) }];
-                [_items addObject:_item];
+                _item.handler = ^(CPListItem *selectedItem, void (^completionHandler)(void)) {
+                    NSDictionary *payload = @{
+                      @"templateId": templateId,
+                      @"index": selectedItem.userInfo[@"index"],
+                      @"itemId": selectedItem.userInfo[@"itemId"]
+                    };
+
+                    if (self->hasListeners) {
+                      [self sendEventWithName:@"didSelectListItem" body:payload];
+                    }
+
+                    self.selectedResultBlock = completionHandler;
+                };
+                if (_item) {
+                  [_items addObject:_item];
+                } else {
+                  NSLog(@"The image row item could not be created: %@", item);
+                }
             }
 
         }
@@ -1433,10 +1523,28 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
     [self sendTemplateEventWithName:template name:name json:@{}];
 }
 
-- (void)sendTemplateEventWithName:(CPTemplate *)template name:(NSString*)name json:(NSDictionary*)json {
-    NSMutableDictionary *body = [[NSMutableDictionary alloc] initWithDictionary:json];
-    NSDictionary *userInfo = [template userInfo];
-    [body setObject:[userInfo objectForKey:@"templateId"] forKey:@"templateId"];
+- (void)sendTemplateEventWithName:(CPTemplate *)template name:(NSString *)name json:(NSDictionary *)json {
+    NSMutableDictionary *body = [[NSMutableDictionary alloc] initWithDictionary:json ?: @{}];
+
+    NSString *templateId = nil;
+    NSDictionary *userInfo = nil;
+
+    if ([template respondsToSelector:@selector(userInfo)]) {
+        userInfo = [template userInfo];
+    }
+
+    if ([userInfo isKindOfClass:[NSDictionary class]]) {
+        id value = userInfo[@"templateId"];
+        if ([value isKindOfClass:[NSString class]]) {
+            templateId = (NSString *)value;
+        }
+    }
+
+    if (templateId.length > 0) {
+        body[@"templateId"] = templateId;
+    }
+    body[@"templateId"] = templateId ?: @"";
+
     if (hasListeners) {
         [self sendEventWithName:name body:body];
     }
@@ -1536,14 +1644,6 @@ RCT_EXPORT_METHOD(updateMapTemplateMapButtons:(NSString*) templateId mapButtons:
 - (void)searchTemplate:(CPSearchTemplate *)searchTemplate updatedSearchText:(NSString *)searchText completionHandler:(void (^)(NSArray<CPListItem *> * _Nonnull))completionHandler {
     [self sendTemplateEventWithName:searchTemplate name:@"updatedSearchText" json:@{ @"searchText": searchText }];
     self.searchResultBlock = completionHandler;
-}
-
-# pragma ListTemplate
-
-- (void)listTemplate:(CPListTemplate *)listTemplate didSelectListItem:(CPListItem *)item completionHandler:(void (^)(void))completionHandler {
-    NSNumber* index = [item.userInfo objectForKey:@"index"];
-    [self sendTemplateEventWithName:listTemplate name:@"didSelectListItem" json:@{ @"index": index }];
-    self.selectedResultBlock = completionHandler;
 }
 
 # pragma TabBarTemplate

--- a/packages/react-native-carplay/ios/RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RNCarPlay.m
@@ -216,6 +216,36 @@ RCT_EXPORT_METHOD(checkForConnection) {
     }
 }
 
+RCT_REMAP_METHOD(getConnectionStatus,
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  // Check for CarPlay scene
+  BOOL carplayConnected = NO;
+  for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+    if ([scene isKindOfClass:[CPTemplateApplicationScene class]]) {
+      carplayConnected = YES;
+      break;
+    }
+  }
+
+  // Check for phone (active foreground window scene)
+  BOOL phoneConnected = NO;
+  for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+    if ([scene isKindOfClass:[UIWindowScene class]] &&
+        scene.activationState == UISceneActivationStateForegroundActive) {
+      phoneConnected = YES;
+      break;
+    }
+  }
+
+  resolve(@{
+    @"carplay": @(carplayConnected),
+    @"phone": @(phoneConnected)
+  });
+}
+
+
 RCT_EXPORT_METHOD(createTemplate:(NSString *)templateId config:(NSDictionary*)config callback:(id)callback) {
     // Get the shared instance of the RNCPStore class
     RNCPStore *store = [RNCPStore sharedManager];

--- a/packages/react-native-carplay/src/CarPlay.ts
+++ b/packages/react-native-carplay/src/CarPlay.ts
@@ -83,6 +83,7 @@ export interface InternalCarPlay extends NativeModule {
   getMaximumListItemImageSize(id: string): Promise<ImageSize>;
   getMaximumNumberOfGridImages(id: string): Promise<number>;
   getMaximumListImageRowItemImageSize(id: string): Promise<ImageSize>;
+  getTopTemplateId(): Promise<string>;
   reactToSelectedResult(status: boolean): void;
   updateListTemplateSections(id: string, config: unknown): void;
   updateListTemplateItem(id: string, config: unknown): void;
@@ -279,11 +280,10 @@ export class CarPlayInterface {
   }
 
   /**
-   * The top-most template in the navigation hierarchy stack.
-   * @todo Not implemented yet
+   * The id of the top-most template in the navigation hierarchy stack.
    */
   public get topTemplate(): Promise<string> {
-    return Promise.resolve('');
+    return this.bridge.getTopTemplateId();
   }
 
   /**

--- a/packages/react-native-carplay/src/CarPlay.ts
+++ b/packages/react-native-carplay/src/CarPlay.ts
@@ -86,6 +86,7 @@ export interface InternalCarPlay extends NativeModule {
   getMaximumListImageRowItemImageSize(id: string): Promise<ImageSize>;
   getTopTemplateId(): Promise<string>;
   reactToSelectedResult(status: boolean): void;
+  updateListTemplate(id: string, config: unknown): void;
   updateListTemplateSections(id: string, config: unknown): void;
   updateListTemplateItem(id: string, config: unknown): void;
   updateListItemById(itemId: string, config: unknown): void;

--- a/packages/react-native-carplay/src/CarPlay.ts
+++ b/packages/react-native-carplay/src/CarPlay.ts
@@ -158,14 +158,53 @@ export class CarPlayInterface {
    */
   public emitter = new NativeEventEmitter(RNCarPlay);
 
+  public selectListItemListenerMap = new Map<
+    string,
+    (e: { templateId: string; index: number; itemId?: string }) => void
+  >();
+  public selectListItemRowImageListenerMap = new Map<
+    string,
+    (e: {
+      templateId: string;
+      index: number;
+      itemId?: string;
+      imageIndex: number;
+      imageId?: string;
+    }) => void
+  >();
+
   private onConnectCallbacks = new Set<OnConnectCallback>();
   private onDisconnectCallbacks = new Set<OnDisconnectCallback>();
 
   constructor() {
     this.emitter.addListener('didConnect', (window: WindowInformation) => {
-      console.log('we are connected yes!');
+      console.log('Carplay Connected');
       this.connected = true;
       this.window = window;
+      this.emitter.addListener(
+        'didSelectListItem',
+        (e: { templateId: string; index: number; itemId?: string }) => {
+          const templateListener = this.selectListItemListenerMap.get(e.templateId);
+          if (templateListener) {
+            templateListener(e);
+          }
+        },
+      );
+      this.emitter.addListener(
+        'didSelectListItemRowImage',
+        (e: {
+          templateId: string;
+          index: number;
+          itemId?: string;
+          imageIndex: number;
+          imageId?: string;
+        }) => {
+          const templateListener = this.selectListItemRowImageListenerMap.get(e.templateId);
+          if (templateListener) {
+            templateListener(e);
+          }
+        },
+      );
       this.onConnectCallbacks.forEach(callback => {
         callback(window);
       });
@@ -173,6 +212,8 @@ export class CarPlayInterface {
     this.emitter.addListener('didDisconnect', () => {
       this.connected = false;
       this.window = undefined;
+      this.emitter.removeAllListeners('didSelectListItem');
+      this.emitter.removeAllListeners('didSelectListItemRowImage');
       this.onDisconnectCallbacks.forEach(callback => {
         callback();
       });

--- a/packages/react-native-carplay/src/CarPlay.ts
+++ b/packages/react-native-carplay/src/CarPlay.ts
@@ -33,6 +33,7 @@ import { RoutePreviewNavigationTemplate } from './templates/android/RoutePreview
 
 export interface InternalCarPlay extends NativeModule {
   checkForConnection(): void;
+  getConnectionStatus(): Promise<{carplay: boolean, phone: boolean}>;
   setRootTemplate(templateId: string, animated: boolean): void;
   pushTemplate(templateId: string, animated: boolean): void;
   popToTemplate(templateId: string, animated: boolean): void;

--- a/packages/react-native-carplay/src/CarPlay.ts
+++ b/packages/react-native-carplay/src/CarPlay.ts
@@ -87,6 +87,7 @@ export interface InternalCarPlay extends NativeModule {
   reactToSelectedResult(status: boolean): void;
   updateListTemplateSections(id: string, config: unknown): void;
   updateListTemplateItem(id: string, config: unknown): void;
+  updateListItemById(itemId: string, config: unknown): void;
   reactToUpdatedSearchText(id: string, items: unknown): void;
   updateTabBarTemplates(id: string, config: unknown): void;
   activateVoiceControlState(id: string, identifier: string): void;

--- a/packages/react-native-carplay/src/interfaces/ListItem.ts
+++ b/packages/react-native-carplay/src/interfaces/ListItem.ts
@@ -29,7 +29,7 @@ export interface ListItem {
   /**
    * Url for image displayed on the leading edge of the list item cell.
    */
-  imgUrl?: null;
+  imgUrl?: string;
   /**
    * Url for image displayed on the leading edge of the list item cell.
    * @namespace iOS

--- a/packages/react-native-carplay/src/interfaces/ListItem.ts
+++ b/packages/react-native-carplay/src/interfaces/ListItem.ts
@@ -36,6 +36,11 @@ export interface ListItem {
    */
   imgUrls?: string[];
   /**
+   * ids corresponding to the images in imgUrls or images which will be passed back on list row item selected
+   * @namespace iOS
+  */
+  imageIds?: string[];
+  /**
    * A Boolean value indicating whether the list item cell shows a disclosure indicator on the trailing edge of the list item cell.
    * @namespace iOS
    */

--- a/packages/react-native-carplay/src/templates/ListTemplate.ts
+++ b/packages/react-native-carplay/src/templates/ListTemplate.ts
@@ -50,7 +50,12 @@ export interface ListTemplateConfig extends TemplateConfig {
    * When the returned promise is resolved the spinner will hide.
    * @param item Object with the selected index
    */
-  onItemSelect?(item: { templateId: string; index: number }): Promise<void>;
+  onItemSelect?(
+    item: {
+      templateId: string;
+      index: number;
+      itemId?: string;
+    }): Promise<void>;
 
   /**
    * Fired when image row item is selected.
@@ -61,7 +66,9 @@ export interface ListTemplateConfig extends TemplateConfig {
   onImageRowItemSelect?(item: {
     templateId: string;
     index: number;
+    itemId?: string;
     imageIndex: number;
+    imageId?: string;
   }): Promise<void>;
 
   /**
@@ -128,20 +135,29 @@ export class ListTemplate extends Template<ListTemplateConfig> {
   constructor(public config: ListTemplateConfig) {
     super(config);
 
-    CarPlay.emitter.addListener('didSelectListItem', (e: { templateId: string; index: number }) => {
-      if (config.onItemSelect && e.templateId === this.id) {
-        void Promise.resolve(config.onItemSelect(e)).then(() => {
-          if (Platform.OS === 'ios') {
-            CarPlay.bridge.reactToSelectedResult(true);
-          }
-        });
-      }
-    });
+    CarPlay.selectListItemListenerMap.set(
+      this.id,
+      (e: { templateId: string; index: number; itemId?: string }) => {
+        if (config.onItemSelect) {
+          void Promise.resolve(config.onItemSelect(e)).then(() => {
+            if (Platform.OS === 'ios') {
+              CarPlay.bridge.reactToSelectedResult(true);
+            }
+          });
+        }
+      },
+    );
 
-    CarPlay.emitter.addListener(
-      'didSelectListItemRowImage',
-      (e: { templateId: string; index: number; imageIndex: number }) => {
-        if (config.onImageRowItemSelect && e.templateId === this.id) {
+    CarPlay.selectListItemRowImageListenerMap.set(
+      this.id,
+      (e: {
+        templateId: string;
+        index: number;
+        itemId?: string;
+        imageIndex: number;
+        imageId?: string;
+      }) => {
+        if (config.onImageRowItemSelect) {
           void Promise.resolve(config.onImageRowItemSelect(e)).then(() => {
             if (Platform.OS === 'ios') {
               CarPlay.bridge.reactToSelectedResult(true);


### PR DESCRIPTION
Various improvements to ListTemplates. It is much easier to build a handler which responds based on the ListItem `id` and can update ListItems based on their `id`. For example, in an audio app, the ListItem ids can be set to correspond to the ids of the audio content and a single handler can play the appropriate file without having to keep track of the section or item indexes where the content items are presented. The isPlaying and playbackProgress are much easier to update based on the ListItem id vs those other properties.